### PR TITLE
Speed up adding echoes

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -327,7 +327,12 @@ class TDomainEchoesGenerator(BaseGenerator):
             omega = omega_temp
         omega.resize(len(hp))
         frozen_params["omega"] = omega
-        
+        # figure out the merger time
+        t_merger = float((hp**2 + hc**2).numpy().argmax() * hp.delta_t +
+                         hp.start_time)
+        frozen_params['t_merger'] = t_merger
+        # sample times
+        frozen_params['sampletimesarray'] = hp.sample_times.numpy()
         super(TDomainEchoesGenerator, self).__init__(
             waveform.get_td_echoes_waveform, variable_args=variable_args,
             **frozen_params)

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -754,9 +754,23 @@ def get_td_echoes_waveform(template=None, **kwargs):
     n_echoes = input_params["n_echoes"]
     amplitude = input_params["amplitude"]
     gamma = input_params["gamma"]
+    try:
+        t_merger = input_params["t_merger"]
+    except KeyError:
+        t_merger = None
+    try:
+        sampletimesarray = input_params["sampletimesarray"]
+    except KeyError:
+        sampletimesarray = None
+    try:
+        include_imr = input_params['include_imr']
+    except KeyError:
+        include_imr = False
     return add_echoes(hp, hc, omega, t0trunc, t_echo,
                       del_t_echo, n_echoes, amplitude, gamma,
-                      inclination=inclination, timestep=None)
+                      inclination=inclination, t_merger=t_merger,
+                      sampletimesarray=sampletimesarray,
+                      include_imr=include_imr)
 
 # add echoes to cpu_td
 echoes_apprx = 'TDechoes1'


### PR DESCRIPTION
Speeds up adding echoes by fixing some issues related to mixing `TimeSeries` and numpy arrays. Also fixes some PEP8 issues, and makes turning on the IMR waveform an optional argument. Testing with GW151226-like parameters, echoes generation goes from taking ~18s to ~5ms, a speed up of 4 orders of magnitude.