### PR TITLE
Base exclusion on amplitude

### DIFF
--- a/pycbc/waveform/echoeswaveformPComega_pycbc.py
+++ b/pycbc/waveform/echoeswaveformPComega_pycbc.py
@@ -120,12 +120,10 @@ def add_echoes(hp, hc, omega, t0trunc, t_echo, del_t_echo, n_echoes, amplitude,
         damping_factor = amplitude * gamma**(j) * ((-1.0)**(j+1))
         # apply to hp
         echo_slice = slice(del_t_echo_steps, del_t_echo_steps + hp_numpy.size)
-        hparray[echo_slice] += hp_numpy
-        hparray[echo_slice] *= damping_factor
+        hparray[echo_slice] += hp_numpy * damping_factor
         # apply to hc
         echo_slice = slice(del_t_echo_steps, del_t_echo_steps + hc_numpy.size)
-        hcarray[echo_slice] += hc_numpy
-        hcarray[echo_slice] *= damping_factor
+        hcarray[echo_slice] += hc_numpy * damping_factor
 
     # add the original waveform, if desired
     if include_imr:


### PR DESCRIPTION
Currently `add_echoes` tries to only include parts of the waveform above some threshold. There are a couple of issues in the way this is done currently: first, the starting index is based on when the taper window exceeds 0.01. However, due to numerical junk at the beginning of the waveform, this happens almost immediately. (See [this plot](https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/github_prs/an_pr6/tapercoeffplot.png).) Second, the ending index was only based on where the original waveform dropped below `0.01 * max(max(hp), max(hc))`. But just taking the max ignored that the waveform goes negative, and by only considering the individual polarizations, it was not necessarily finding where the amplitude drops below some value of the peak.

This fixes this by calculating the amplitude of the tapered waveform, then only keeping the bit where the amplitude exceeds `1e-4 * max(amplitude)`. This results in a large number of zeros being excluded from the beginning, and actually includes slightly more cycles at the end. Overall, the waveform generation is now twice as fast, dropping from ~5ms to ~2ms for a GW151226-like signal. See [this plot](https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/github_prs/an_pr6/comparison.png) for a comparison between the waveforms, and [this plot](https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/github_prs/an_pr6/comparison-zoom.png) for a zoom on the first echo.

Depends on #5, although if this is merged, #5 can just be deleted.