### PR TITLE
Add phase_shift parameter to waveform generation

### DIFF
--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -378,6 +378,9 @@ chirp_distance = Parameter("chirp_distance",
 coa_phase = Parameter("coa_phase",
                 dtype=float, default=0., label=r"$\phi_c$",
                 description="Coalesence phase of the binary (in rad).")
+phase_shift = Parameter("phase_shift",
+                dtype=float, default=0., label=r"$\Delta \phi$",
+                description="Constant phase offset (in rad).")
 inclination = Parameter("inclination",
                 dtype=float, default=0., label=r"$\iota$",
                 description="Inclination (rad), defined as the angle between "
@@ -467,7 +470,8 @@ location_params = ParameterList([tc, ra, dec, polarization])
 # frame. Note: we include distance here, as it is typically used for generating
 # waveforms.
 orientation_params = ParameterList\
-    ([distance, coa_phase, inclination, long_asc_nodes, mean_per_ano])
+    ([distance, coa_phase, phase_shift, inclination, long_asc_nodes,
+      mean_per_ano])
 
 # the extrinsic parameters of a waveform
 extrinsic_params = orientation_params + location_params

--- a/pycbc/waveform/utils.py
+++ b/pycbc/waveform/utils.py
@@ -469,6 +469,41 @@ def apply_fd_time_shift(htilde, shifttime, kmin=0, fseries=None, copy=True):
         htilde *= shift
     return htilde
 
+def apply_phase_shift(h, phase_shift, copy=True):
+    """Applies a constant phase shift to a waveform.
+
+    Parameters
+    ----------
+    h : FrequencySeries or TimeSeries
+        The waveform to apply the shift to. If a TimeSeries, will be converted
+        to frequency domain, the shift will be applied, then the waveform
+        will be converted back.
+    phase_shift : float
+        The value to apply.
+    copy : bool, optional
+        Copy the vector before applying. Only applies if ``h`` is a
+        FrequencySeries. Default is True.
+
+    Returns
+    -------
+    FrequencySeries or TimeSeries
+        The waveform with the shift applied. Return type is the same as ``h``.
+    """
+    # check tha tthe phase shift isn't just zero
+    if phase_shift == 0.:
+        if copy:
+            h = h.copy()
+        return h
+    istimeseries = isinstance(h, TimeSeries)
+    if istimeseries:
+        h = h.to_frequencyseries()
+    elif copy:
+        h = h.copy()
+    h *= numpy.exp(1j * phase_shift)
+    if istimeseries:
+        h = h.to_timeseries()
+    return h
+
 def td_taper(out, start, end, beta=8, side='left'):
     """Applies a taper to the given TimeSeries.
 

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -453,7 +453,14 @@ def get_td_waveform(template=None, **kwargs):
     if input_params['approximant'] not in wav_gen:
         raise ValueError("Approximant %s not available" %
                             (input_params['approximant']))
-    return wav_gen[input_params['approximant']](**input_params)
+    try:
+        phase_shift = input_params['phase_shift']
+    except KeyError:
+        phase_shift = 0.
+    hp, hc = wav_gen[input_params['approximant']](**input_params)
+    hp = wfutils.apply_phase_shift(hp, phase_shift, copy=False)
+    hc = wfutils.apply_phase_shift(hc, phase_shift, copy=False)
+    return hp, hc
 
 get_td_waveform.__doc__ = get_td_waveform.__doc__.format(
     params=parameters.td_waveform_params.docstr(prefix="    ",
@@ -495,8 +502,14 @@ def get_fd_waveform(template=None, **kwargs):
                 raise NoWaveformError("cannot generate waveform: f_lower >= f_final")
     except KeyError:
         pass
-
-    return wav_gen[input_params['approximant']](**input_params)
+    try:
+        phase_shift = input_params['phase_shift']
+    except KeyError:
+        phase_shift = 0.
+    hp, hc = wav_gen[input_params['approximant']](**input_params)
+    hp = wfutils.apply_phase_shift(hp, phase_shift, copy=False)
+    hc = wfutils.apply_phase_shift(hc, phase_shift, copy=False)
+    return hp, hc
 
 get_fd_waveform.__doc__ = get_fd_waveform.__doc__.format(
     params=parameters.fd_waveform_params.docstr(prefix="    ",


### PR DESCRIPTION
Allows a constant phase shift to be applied to waveforms by setting a `phase_shift` argument.