### PR TITLE
Make omega optional argument

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -31,6 +31,7 @@ from pycbc import filter
 from pycbc import transforms
 from pycbc.types import TimeSeries
 from pycbc.waveform import parameters
+from .echoeswaveformPComega_pycbc import get_omega
 from pycbc.waveform.utils import apply_fd_time_shift, taper_timeseries, \
                                  ceilpow2
 from pycbc.detector import Detector
@@ -309,24 +310,7 @@ class TDomainEchoesGenerator(BaseGenerator):
         frozen_params["hc"] = hc
         if len(hc) != len(hp): 
             print("hp and hc have unequal length")
-        omega = 2. * numpy.pi * utils.frequency_from_polarizations(hp.trim_zeros(),
-                                                                 hc.trim_zeros())
-        omega_temp = numpy.zeros(len(hp))
-        first_zero_index_hp = 0
-        first_zero_index_hc = 0
-        if hp[0] == 0 and hc[0] == 0:
-            print('Active')
-            while hp[first_zero_index_hp] == 0:
-                first_zero_index_hp += 1
-            while hc[first_zero_index_hc] == 0:
-                first_zero_index_hc += 1
-            if first_zero_index_hp != first_zero_index_hc:
-                print('Polarisations have unequal number of leading zeros.')
-            omega_temp[:max(first_zero_index_hp, first_zero_index_hc)] = \
-                omega[max(first_zero_index_hp, first_zero_index_hc)]
-            omega = omega_temp
-        omega.resize(len(hp))
-        frozen_params["omega"] = omega
+        frozen_params["omega"] = get_omega(hp, hc)
         # figure out the merger time
         t_merger = float((hp**2 + hc**2).numpy().argmax() * hp.delta_t +
                          hp.start_time)

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -760,6 +760,7 @@ def get_td_echoes_waveform(template=None, **kwargs):
         imrargs = input_params.copy()
         imrargs['approximant'] = apprx
         hp, hc = get_td_waveform(**imrargs)
+        omega = None
     # get the echo parameters
     t0trunc = input_params["t0trunc"]
     t_echo = input_params["t_echo"]
@@ -779,10 +780,10 @@ def get_td_echoes_waveform(template=None, **kwargs):
         include_imr = input_params['include_imr']
     except KeyError:
         include_imr = False
-    return add_echoes(hp, hc, omega, t0trunc, t_echo,
+    return add_echoes(hp, hc, t0trunc, t_echo,
                       del_t_echo, n_echoes, amplitude, gamma,
                       inclination=inclination, t_merger=t_merger,
-                      sampletimesarray=sampletimesarray,
+                      sampletimesarray=sampletimesarray, omega=omega,
                       include_imr=include_imr)
 
 # add echoes to cpu_td


### PR DESCRIPTION
Make `omega` an optional argument in `add_echoes` and moves calculating omega(t) to it's own function. If `omega` isn't provided, `get_omega` is called to calculate it. This should allow the injection module to create echoes again.